### PR TITLE
[Transfer] Performance update & Renaming

### DIFF
--- a/src/main/java/server/transfer/TransferManager.java
+++ b/src/main/java/server/transfer/TransferManager.java
@@ -53,8 +53,8 @@ public class TransferManager {
     }
 
 	private void startGraphiteTransfer(List<String> topics) {
-    	connector = new GraphiteConnector(topics, new GraphiteSender());
-    	connector.run();
+    	connector = new GraphiteConnector(topics);
+    	connector.run(new GraphiteSender());
     }
     
 }

--- a/src/main/java/server/transfer/connector/Connector.java
+++ b/src/main/java/server/transfer/connector/Connector.java
@@ -43,7 +43,7 @@ public abstract class Connector {
     /**
      * Starts the transferring-process
      */
-    public abstract void run();
+    public abstract void run(Sender sender);
 
     /**
      * Stops the transferring-process

--- a/src/main/java/server/transfer/connector/GraphiteConnector.java
+++ b/src/main/java/server/transfer/connector/GraphiteConnector.java
@@ -28,15 +28,16 @@ public class GraphiteConnector extends Connector {
      * @param topics The topics that the consumer should subscribe to
      * @param sender Sends the data to a specified component, normally a {@link GraphiteSender}
      */
-	public GraphiteConnector(List<String> topics, Sender sender) {
+	public GraphiteConnector(List<String> topics) {
     	this.topics = topics;
-    	this.sender = sender;
     }
 
     /**
      * Starts the process of consumation and readying the sender object
      */
-    public void run() {
+    public void run(Sender sender) {
+    	this.sender = sender;
+    	
     	Properties consumerProperties = getConsumerProperties();
         consumer = new KafkaConsumer<String, ObservationData>(consumerProperties);
         consumer.subscribe(topics);
@@ -68,11 +69,13 @@ public class GraphiteConnector extends Connector {
      * Stops the process
      */
     public void stop() {
-    	logger.info("Waking up connector...");
+    	
+    	this.sender.close();
+    	logger.info("Waking up consumer...");
         consumer.wakeup();
 
         try {
-            logger.info("Waiting for connector to shutdown...");
+            logger.info("Waiting for consumer to shutdown...");
             shutdownLatch.await();
         } catch (InterruptedException e) {
             logger.error("Exception thrown waiting for shutdown", e);

--- a/src/main/java/server/transfer/sender/ConsoleSender.java
+++ b/src/main/java/server/transfer/sender/ConsoleSender.java
@@ -26,4 +26,9 @@ public class ConsoleSender extends Sender {
 		System.out.println(payload.asString());
 	}
 
+	@Override
+	public void close() {
+		
+	}
+
 }

--- a/src/main/java/server/transfer/sender/GraphiteSender.java
+++ b/src/main/java/server/transfer/sender/GraphiteSender.java
@@ -19,6 +19,7 @@ import org.python.modules.cPickle;
 import server.transfer.config.GraphiteConfig;
 import server.transfer.converter.GraphiteConverter;
 import server.transfer.data.ObservationData;
+import server.transfer.sender.connection.SocketManager;
 
 /**
  * Sends data to Graphite
@@ -48,9 +49,7 @@ public class GraphiteSender extends Sender {
 	 */
 	@Override
 	public void send(ConsumerRecords<String, ObservationData> records) {
-		if (socket == null) {
-			som.connect(this.socket, GraphiteConfig.getGraphiteHostName(), GraphiteConfig.getGraphitePort());
-		} else if (!socket.isConnected()) {
+		if (socket == null || socket.isClosed()) {
 			som.reconnect(this.socket);
 		}
 		
@@ -92,6 +91,15 @@ public class GraphiteSender extends Sender {
 		records = new ConsumerRecords<String, ObservationData>(recordsMap);
 
 		this.send(records);
+	}
+
+	@Override
+	public void close() {
+		try {
+			socket.close();
+		} catch (IOException e) {
+			logger.error("Could not close socket.", e);
+		}
 	}
 	
 }

--- a/src/main/java/server/transfer/sender/Sender.java
+++ b/src/main/java/server/transfer/sender/Sender.java
@@ -18,5 +18,10 @@ public abstract class Sender {
      * @param records Multiple records of data from Kafka
      */
     public abstract void send(ConsumerRecords<String, ObservationData> records);
+    
+    /**
+     * Closes the sender and the connection
+     */
+    public abstract void close();
 
 }

--- a/src/main/java/server/transfer/sender/connection/SocketManager.java
+++ b/src/main/java/server/transfer/sender/connection/SocketManager.java
@@ -1,4 +1,4 @@
-package server.transfer.sender;
+package server.transfer.sender.connection;
 
 import java.io.IOException;
 import java.net.Socket;

--- a/src/test/java/server/transfer/consumer/GraphiteConsumerTests.java
+++ b/src/test/java/server/transfer/consumer/GraphiteConsumerTests.java
@@ -48,7 +48,7 @@ public class GraphiteConsumerTests {
 		
 		ArrayList<String> topics = new ArrayList<String>();
 		topics.add(topic);
-		final GraphiteConnector consumer = new GraphiteConnector(topics, new ConsoleSender());
+		final GraphiteConnector consumer = new GraphiteConnector(topics);
 		
 		KafkaProducer<String, String> producer = new KafkaProducer<>(getProducerProperties());
 		producer.send(new ProducerRecord<String, String>(topic, sData));
@@ -56,7 +56,7 @@ public class GraphiteConsumerTests {
 		
 		Thread t = new Thread(new Runnable() {
 	        public void run() {
-	        	consumer.run();
+	        	consumer.run(new ConsoleSender());
 	        }
 	    });
 	    t.start();


### PR DESCRIPTION
+ Sender can now be closed! (closes socket)
+ GraphiteConnector closes Sender before shutdown
+ NOW: Sender could be null for GraphiteConnector -> Sender is now set in method "run(Sender sender)" instead of setting it in the constructor
+ SocketManager now in package "server.transfer.sender.connection"